### PR TITLE
fix: allow multiple file uploads in report form

### DIFF
--- a/app/(app)/report/page.tsx
+++ b/app/(app)/report/page.tsx
@@ -14,20 +14,45 @@ import { Textarea } from '@/components/ui/textarea'
 import { sendReportEmail } from '@/lib/actions/report'
 import { useFormStatus } from 'react-dom'
 import { toast } from 'sonner'
-import React, { useRef } from 'react'
+import React, { useRef, useState } from 'react'
 import { Bug } from 'lucide-react'
 
 export default function ReportPage() {
   const formRef = useRef<HTMLFormElement>(null)
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([])
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    if (!e.target.files) return
+    const newFiles = Array.from(e.target.files)
+
+    // Avoid duplicates by checking name + size
+    const uniqueFiles = newFiles.filter(
+      (newFile) =>
+        !selectedFiles.some(
+          (existingFile) =>
+            existingFile.name === newFile.name && existingFile.size === newFile.size
+        )
+    )
+
+    setSelectedFiles((prev) => [...prev, ...uniqueFiles])
+  }
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
+
     const formData = new FormData(formRef.current!)
+
+    // Append custom files from state
+    selectedFiles.forEach((file) => {
+      formData.append('screenshots', file)
+    })
+
     const result = await sendReportEmail(formData)
 
     if (result.success) {
       toast.success(result.message)
       formRef.current?.reset()
+      setSelectedFiles([]) // reset accumulated files
     } else {
       toast.error(result.message)
     }
@@ -42,6 +67,7 @@ export default function ReportPage() {
       <p className="text-muted-foreground text-[17px] tracking-tight">
         Spotted a bug or problem? We're here to fix it—just give us the details.
       </p>
+
       <form
         ref={formRef}
         onSubmit={handleSubmit}
@@ -52,31 +78,23 @@ export default function ReportPage() {
           <Label htmlFor="title" className="text-muted-foreground">
             Issue Title
           </Label>
-          <Input
-            type="text"
-            id="title"
-            name="title"
-            required
-            // placeholder="Short title for your report"
-          />
+          <Input type="text" id="title" name="title" required />
         </div>
+
         <div className="space-y-2">
           <Label htmlFor="description" className="text-muted-foreground">
             Description
           </Label>
           <Textarea id="description" name="description" required />
         </div>
+
         <div className="space-y-2">
           <Label htmlFor="email" className="text-muted-foreground">
             Your Email (optional)
           </Label>
-          <Input
-            type="email"
-            name="email"
-            id="email"
-            placeholder="you@example.com"
-          />
+          <Input type="email" name="email" id="email" placeholder="you@example.com" />
         </div>
+
         <div className="space-y-2">
           <Label htmlFor="type" className="text-muted-foreground">
             Issue Type (optional)
@@ -93,6 +111,7 @@ export default function ReportPage() {
             </SelectContent>
           </Select>
         </div>
+
         <div className="space-y-2">
           <Label htmlFor="screenshots" className="text-muted-foreground">
             Screenshot (optional, multiples allowed)
@@ -100,12 +119,21 @@ export default function ReportPage() {
           <Input
             type="file"
             id="screenshots"
-            name="screenshots"
             accept="image/*"
             className="cursor-pointer"
             multiple
+            onChange={handleFileChange}
           />
+
+          {selectedFiles.length > 0 && (
+            <ul className="text-sm text-muted-foreground mt-2 space-y-1">
+              {selectedFiles.map((file, idx) => (
+                <li key={idx}>📎 {file.name}</li>
+              ))}
+            </ul>
+          )}
         </div>
+
         <SubmitButton />
       </form>
     </div>
@@ -115,7 +143,7 @@ export default function ReportPage() {
 function SubmitButton() {
   const { pending } = useFormStatus()
   return (
-    <Button className="font-geist cursor-pointer">
+    <Button className="font-geist cursor-pointer" type="submit" disabled={pending}>
       {pending ? 'Submitting...' : 'Submit Report'}
     </Button>
   )


### PR DESCRIPTION
### Summary

Fixes a bug where selecting files one-by-one in the file input would overwrite previously selected files.

### Fixes

- Accumulates selected files using state
- Prevents duplicates
- Manually appends files to FormData
- Resets form and state on successful submission
- Shows selected file names in UI

Let me know if any changes are needed!
